### PR TITLE
SC_5 subset adata

### DIFF
--- a/src/sparrow/_tests/test_image/test_shapes_to_labels.py
+++ b/src/sparrow/_tests/test_image/test_shapes_to_labels.py
@@ -21,4 +21,6 @@ def test_add_label_layer_from_shapes_layer(sdata_multi_c):
 
     assert "masks_whole_unit_test" in [*sdata_multi_c.labels]
 
-    np.array_equal(sdata_multi_c["masks_whole"].data.compute(), sdata_multi_c["masks_whole_unit_test"].data.compute())
+    assert np.array_equal(
+        sdata_multi_c["masks_whole"].data.compute(), sdata_multi_c["masks_whole_unit_test"].data.compute()
+    )

--- a/src/sparrow/_tests/test_table/test_clustering.py
+++ b/src/sparrow/_tests/test_table/test_clustering.py
@@ -23,10 +23,27 @@ def test_leiden(sdata_multi_c):
         table_layer="table_intensities",
         output_layer="table_intensities_clustered",
         key_added="leiden",
+        index_names_var=["0", "2", "5", "20"],
         random_state=100,
         overwrite=True,
     )
     assert "leiden" in sdata_multi_c.tables["table_intensities_clustered"].obs.columns
+    assert sdata_multi_c["table_intensities_clustered"].shape == (674, 4)
+    assert sdata_multi_c["table_intensities_clustered"].var.index.to_list() == ["0", "2", "5", "20"]
+
+    sdata_multi_c = leiden(
+        sdata_multi_c,
+        labels_layer="masks_whole",
+        table_layer="table_intensities",
+        output_layer="table_intensities_clustered",
+        key_added="leiden",
+        index_positions_var=[0, 2, 5],
+        random_state=100,
+        overwrite=True,
+    )
+    assert "leiden" in sdata_multi_c.tables["table_intensities_clustered"].obs.columns
+    assert sdata_multi_c["table_intensities_clustered"].shape == (674, 3)
+    assert sdata_multi_c["table_intensities_clustered"].var.index.to_list() == ["0", "2", "5"]
 
 
 def test_kmeans(sdata_multi_c):


### PR DESCRIPTION
implementation of https://github.com/saeyslab/harpy/issues/3, see https://github.com/saeyslab/harpy/blob/2f3e8f012460c8d573ae4ad0e161138ad96a7cac/src/sparrow/_tests/test_table/test_clustering.py#L18 for usage. 

Currently opted to subset the adata, and removing the channels that are not selected for clustering. 

I do not feel comfortable with the alternative: "adding this as an annotation like a boolean mask "lineage" in the AnnData.var ",  because for a user it not clear any more from the anndata where the e.g. leiden clusters, neighbours,... where calculated on.
If user is interested in keeping all channels, the resulting table after clustering could be saved in a different table slot of the SpatialData object. 