### PR TITLE
Sc 19 bounding box query

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -155,3 +155,18 @@ Plotting functions.
     pl.cluster_cleanliness
     pl.nhood_enrichment
 ```
+
+## Utils
+
+Utility functions.
+
+```{eval-rst}
+
+.. module:: sparrow.utils
+.. currentmodule:: sparrow
+
+.. autosummary::
+    :toctree: generated
+
+    utils.bounding_box_query
+```

--- a/docs/tutorials/coordinate_systems.ipynb
+++ b/docs/tutorials/coordinate_systems.ipynb
@@ -634,6 +634,33 @@
     "    assert sdata[ \"table\" ][ sdata[ \"table\" ].obs[ _REGION_KEY ] == f\"labels_{to_coordinate_system}\"].shape[0] ==\\\n",
     "          len( sdata[ f\"shapes_{to_coordinate_system}\" ] ) + len( sdata[ f\"filtered_low_counts_shapes_{to_coordinate_system}\" ] ) + len( sdata[ f\"filtered_size_shapes_{to_coordinate_system}\" ] )"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zarr_path = os.path.join( default_tmp_path, f\"sdata_{uuid.uuid4()}.zarr\") # output path for queried sdata\n",
+    "\n",
+    "labels_layer = [\"labels_a1_1\", \"labels_a1_2\", ]\n",
+    "crd = [(600, 1000, 2300, 3000), (700, 1000, 2300, 2500),  ]\n",
+    "to_coordinate_system = [\"a1_1\", \"a1_2\" ]\n",
+    "\n",
+    "sdata_queried=sp.utils.bounding_box_query(\n",
+    "    sdata,\n",
+    "    labels_layer=labels_layer,\n",
+    "    crd = crd,\n",
+    "    to_coordinate_system=to_coordinate_system,\n",
+    "    copy_img_layer=False,\n",
+    "    copy_shapes_layer=False,\n",
+    "    copy_points_layer=False,\n",
+    "    output=zarr_path,\n",
+    "        )\n",
+    "\n",
+    "for _labels_layer in labels_layer:\n",
+    "    assert _labels_layer in sdata_queried.labels"
+   ]
   }
  ],
  "metadata": {

--- a/src/sparrow/_tests/conftest.py
+++ b/src/sparrow/_tests/conftest.py
@@ -12,7 +12,7 @@ from sparrow.datasets.cluster_blobs import cluster_blobs
 from sparrow.datasets.pixie_example import pixie_example
 from sparrow.datasets.proteomics import mibi_example
 from sparrow.datasets.registry import registry
-from sparrow.datasets.transcriptomics import resolve_example
+from sparrow.datasets.transcriptomics import resolve_example, resolve_example_multiple_coordinate_systems
 
 
 @pytest.fixture(scope="function")
@@ -72,6 +72,15 @@ def sdata_multi_c(tmpdir):
 @pytest.fixture
 def sdata_transcripts(tmpdir):
     sdata = resolve_example()
+    # backing store for specific unit test
+    sdata.write(os.path.join(tmpdir, "sdata_transcriptomics.zarr"))
+    sdata = read_zarr(os.path.join(tmpdir, "sdata_transcriptomics.zarr"))
+    yield sdata
+
+
+@pytest.fixture
+def sdata_transcripts_mul_coord(tmpdir):
+    sdata = resolve_example_multiple_coordinate_systems()
     # backing store for specific unit test
     sdata.write(os.path.join(tmpdir, "sdata_transcriptomics.zarr"))
     sdata = read_zarr(os.path.join(tmpdir, "sdata_transcriptomics.zarr"))

--- a/src/sparrow/_tests/test_utils/test_query.py
+++ b/src/sparrow/_tests/test_utils/test_query.py
@@ -1,0 +1,124 @@
+import os
+
+import dask.array as da
+import numpy as np
+import pytest
+from spatialdata import SpatialData
+
+from sparrow.utils._keys import _INSTANCE_KEY, _REGION_KEY
+from sparrow.utils._query import bounding_box_query
+
+
+@pytest.mark.parametrize("crd", [[2000, 3000, 3000, 4000], None])
+def test_bounding_box_query(sdata_transcripts, tmpdir, crd):
+    labels_layer = "segmentation_mask"
+
+    sdata_transcripts_queried = bounding_box_query(
+        sdata_transcripts,
+        labels_layer=labels_layer,
+        to_coordinate_system=None,
+        crd=crd,
+        output=os.path.join(tmpdir, "sdata_queried.zarr"),
+    )
+    assert isinstance(sdata_transcripts_queried, SpatialData)
+    for _table_name in [*sdata_transcripts_queried.tables]:
+        adata = sdata_transcripts_queried.tables[_table_name]
+        ids = adata[adata.obs[_REGION_KEY] == labels_layer].obs[_INSTANCE_KEY].values
+        labels_queried = da.unique(sdata_transcripts_queried.labels[labels_layer].data).compute()
+        labels_queried = labels_queried[labels_queried != 0]
+
+        assert np.all(np.isin(ids, labels_queried))
+
+
+def test_bounding_box_query_no_annotate(sdata_transcripts, tmpdir):
+    labels_layer = "segmentation_mask_expanded"
+
+    sdata_transcripts_queried = bounding_box_query(
+        sdata_transcripts,
+        labels_layer=labels_layer,
+        to_coordinate_system=None,
+        crd=None,
+        output=os.path.join(tmpdir, "sdata_queried.zarr"),
+    )
+    assert isinstance(sdata_transcripts_queried, SpatialData)
+    assert labels_layer in [*sdata_transcripts_queried.labels]
+    # because "segmentation_mask_expanded" does not annotate any tables, no tables will be present in resulting spatialdata object.
+    assert not sdata_transcripts_queried.tables
+
+
+@pytest.mark.parametrize("backed", [True, False])
+def test_bounding_box_query_multiple_coordinate_systems(sdata_transcripts_mul_coord, tmpdir, backed):
+    labels_layer = [
+        "labels_a1_1",
+        "labels_a1_2",
+    ]
+    to_coordinate_system = [
+        "a1_1",
+        "a1_2",
+    ]
+    crd = [
+        (600, 1000, 2300, 3000),
+        (700, 1000, 2300, 2500),
+    ]
+
+    sdata_transcripts_queried = bounding_box_query(
+        sdata_transcripts_mul_coord,
+        labels_layer=labels_layer,
+        to_coordinate_system=to_coordinate_system,
+        crd=crd,
+        output=os.path.join(tmpdir, "sdata_queried.zarr") if backed else None,
+    )
+
+    assert isinstance(sdata_transcripts_queried, SpatialData)
+    for _labels_layer in labels_layer:
+        for _table_name in [*sdata_transcripts_queried.tables]:
+            adata = sdata_transcripts_queried.tables[_table_name]
+            ids = adata[adata.obs[_REGION_KEY] == _labels_layer].obs[_INSTANCE_KEY].values
+            labels_queried = da.unique(sdata_transcripts_queried.labels[_labels_layer].data).compute()
+            labels_queried = labels_queried[labels_queried != 0]
+
+            assert np.all(np.isin(ids, labels_queried))
+
+
+def test_bounding_box_query_multiple_coordinate_systems_crd_none(sdata_transcripts_mul_coord, tmpdir):
+    labels_layer = [
+        "labels_a1_1",
+        "labels_a1_2",
+    ]
+    to_coordinate_system = [
+        "a1_1",
+        "a1_2",
+    ]
+    crd = [
+        (
+            0,
+            50,
+            0,
+            50,
+        ),  # Query will be empty for this crd for labels_layer 'labels_a1_1' -> so all elements that are annoted by labels_a1_1  will be removed from resulting sdata tables.
+        None,  # keep all elements annotated by 'labels_a1_2'
+    ]
+
+    sdata_transcripts_queried = bounding_box_query(
+        sdata_transcripts_mul_coord,
+        labels_layer=labels_layer,
+        to_coordinate_system=to_coordinate_system,
+        crd=crd,
+        output=os.path.join(tmpdir, "sdata_queried.zarr"),
+    )
+
+    assert isinstance(sdata_transcripts_queried, SpatialData)
+    _labels_layer = "labels_a1_1"
+    assert _labels_layer not in sdata_transcripts_queried.labels
+    for _table_name in [*sdata_transcripts_queried.tables]:
+        # check that all elements that are annoted by labels_a1_1  will be removed from resulting sdata tables.
+        assert _labels_layer not in sdata_transcripts_queried.tables[_table_name].obs[_REGION_KEY].values
+        assert _labels_layer not in sdata_transcripts_queried.tables[_table_name].uns["spatialdata_attrs"]["region"]
+    _labels_layer = "labels_a1_2"
+    for _table_name in [*sdata_transcripts_queried.tables]:
+        adata = sdata_transcripts_queried.tables[_table_name]
+        ids = adata[adata.obs[_REGION_KEY] == _labels_layer].obs[_INSTANCE_KEY].values
+        labels_queried = da.unique(sdata_transcripts_queried.labels[_labels_layer].data).compute()
+        labels_queried = labels_queried[labels_queried != 0]
+
+        assert np.all(np.isin(ids, labels_queried))

--- a/src/sparrow/datasets/registry.py
+++ b/src/sparrow/datasets/registry.py
@@ -1,3 +1,5 @@
+import hashlib
+
 import pooch
 
 from sparrow import __version__
@@ -18,6 +20,17 @@ registry = pooch.create(
         "transcriptomics/resolve/mouse/dummy_markers.csv": "3d62c198f5dc1636f2d4faf3c564fad4a3313026f561d2e267e2061a2356432c",
         "transcriptomics/resolve/mouse/markerGeneListMartinNoLow.csv": "1ffefe7d4e72e05ef158ee1e73919b50882a97b6590f4ae977041d6b8b66a459",
         "transcriptomics/resolve/mouse/sdata_transcriptomics.zarr.zip": "32b369195f924f31e57de66a4daa10f34ae049611cfbface46c928fbe40b8fbb",
+        "transcriptomics/resolve/mouse/sdata_transcriptomics_coordinate_systems_unit_test.zarr.zip": "ef2ba1c0f6cc9aebe4cf394d1ee00e0622ea4f9273fedd36feb9c7a2363e41a7",
         "proteomics/mibi_tof/sdata_multi_channel.zarr.zip": "930fd2574666b90d5d6660ad8b52d47afffc9522704b9e6fef39d11c9cfff06e",
     },
 )
+
+
+def _calculate_sha256(file_path):
+    """Helper function to calculate the hash of a file."""
+    sha256_hash = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        # Read the file in chunks to avoid memory issues with large files
+        for byte_block in iter(lambda: f.read(4096), b""):
+            sha256_hash.update(byte_block)
+    return sha256_hash.hexdigest()

--- a/src/sparrow/datasets/transcriptomics.py
+++ b/src/sparrow/datasets/transcriptomics.py
@@ -11,3 +11,12 @@ def resolve_example() -> SpatialData:
     # Fetch and unzip the file
     unzip_path = registry.fetch("transcriptomics/resolve/mouse/sdata_transcriptomics.zarr.zip", processor=pooch.Unzip())
     return read_zarr(os.path.commonpath(unzip_path))
+
+
+def resolve_example_multiple_coordinate_systems() -> SpatialData:
+    """Example transcriptomics dataset"""
+    unzip_path = registry.fetch(
+        "transcriptomics/resolve/mouse/sdata_transcriptomics_coordinate_systems_unit_test.zarr.zip",
+        processor=pooch.Unzip(),
+    )
+    return read_zarr(os.path.commonpath(unzip_path))

--- a/src/sparrow/image/pixel_clustering/_clustering.py
+++ b/src/sparrow/image/pixel_clustering/_clustering.py
@@ -104,7 +104,7 @@ def flowsom(
 
     assert (
         len(output_layer_clusters) == len(output_layer_metaclusters) == len(img_layer)
-    ), "The number of `output_layer_clusters` and `output_layer_metaclusters`  specified should be the equal to the the number of `img_layer` specified."
+    ), "The number of 'output_layer_clusters' and 'output_layer_metaclusters' specified should be the equal to the the number of 'img_layer' specified."
 
     se_image = _get_spatial_element(sdata, layer=img_layer[0])
 

--- a/src/sparrow/utils/__init__.py
+++ b/src/sparrow/utils/__init__.py
@@ -1,3 +1,4 @@
+from sparrow.utils._query import bounding_box_query
 from sparrow.utils.pylogger import get_pylogger
 from sparrow.utils.utils import _export_config, _get_polygons_in_napari_format, _get_raster_multiscale
 

--- a/src/sparrow/utils/_query.py
+++ b/src/sparrow/utils/_query.py
@@ -18,19 +18,47 @@ log = get_pylogger(__name__)
 def bounding_box_query(
     sdata: SpatialData,
     labels_layer: str | Iterable[str],
-    to_coordinate_system: str | Iterable[str] | None,  # if None, will use 'global'
-    crd: tuple[int, int, int, int]
-    | Iterable[tuple[int, int, int, int] | None]
-    | None,  # specifying None is usefull if you want to filter tables layers on specific labels layers (only keep the ones that are annotated)
-    copy_img_layer: bool = True,  # whether to copy all img layers to the new spatialdata object or not.
+    to_coordinate_system: str | Iterable[str] | None,
+    crd: tuple[int, int, int, int] | Iterable[tuple[int, int, int, int] | None] | None,
+    copy_img_layer: bool = True,
     copy_shapes_layer: bool = True,
     copy_points_layer: bool = True,
-    output: str | Path | None = None,  # path to zarr store, if the resulting spatialdata object needs to be backed.
+    output: str | Path | None = None,
 ) -> SpatialData:
     """
-    Bounding box query
+    Query the labels layers of a SpatialData object and the corresponding instances it annotates in `sdata.tables` via a bounding box query.
 
-    Test
+    Parameters
+    ----------
+    sdata
+        The SpatialData object to query.
+    labels_layer
+        The labels layer(s) to query, which can be a single string or an iterable of strings.
+    to_coordinate_system
+        The coordinate system(s) to which the query provided via `crd` is defined. If `None`, will use 'global'.
+    crd
+        Coordinates defining the bounding box, specified as a tuple of four integers (x_min, y_min, x_max, y_max), or an iterable of such tuples.
+        Setting `crd` to `None` can be usefull if you want to filter elments in tables layers that are annotated by specific labels layers.
+        E.g. setting `labels_layer=layer_1` and `crd=None`, will result in AnnData objects in `sdata.tables` containing only instances annotated by `layer_1`.
+    copy_img_layer
+        Whether to copy all image layers to the new SpatialData object. If set to `False`, image layers will not be included in the result.
+    copy_shapes_layer
+        Whether to copy all shapes layers to the new SpatialData object. If set to `False`, shapes layers will not be included in the result.
+    copy_points_layer
+        Whether to copy all points layers to the new SpatialData object. If set to `False`, points layers will not be included in the result.
+    output
+        Path to the zarr store where the resulting SpatialData object will be backed.
+        If None, the new resulting SpatialData object will be persisted in memory.
+
+    Returns
+    -------
+    SpatialData
+        A new SpatialData object containing the extracted bounding box region and associated data layers.
+
+    Raises
+    ------
+    AssertionError
+        If the number of provided `labels_layer`, `crd` and `to_coordinate_system` is not equal.
     """
 
     def _fix_name(name: str | Iterable[str]):

--- a/src/sparrow/utils/_query.py
+++ b/src/sparrow/utils/_query.py
@@ -1,0 +1,165 @@
+from pathlib import Path
+from typing import Iterable
+
+import dask.array as da
+import numpy as np
+from spatialdata import SpatialData, read_zarr
+from spatialdata import bounding_box_query as bounding_box_query_spatialdata
+from spatialdata.transformations import get_transformation
+
+from sparrow.image._image import _get_spatial_element, add_labels_layer
+from sparrow.table._table import add_table_layer
+from sparrow.utils._keys import _INSTANCE_KEY, _REGION_KEY
+from sparrow.utils.pylogger import get_pylogger
+
+log = get_pylogger(__name__)
+
+
+def bounding_box_query(
+    sdata: SpatialData,
+    labels_layer: str | Iterable[str],
+    to_coordinate_system: str | Iterable[str] | None,  # if None, will use 'global'
+    crd: tuple[int, int, int, int]
+    | Iterable[tuple[int, int, int, int] | None]
+    | None,  # specifying None is usefull if you want to filter tables layers on specific labels layers (only keep the ones that are annotated)
+    output: str | Path | None = None,
+    copy_img_layer: bool = True,  # whether to copy all img layers to new spatialdata object or not.
+    copy_shapes_layer: bool = True,
+    copy_points_layer: bool = True,
+) -> SpatialData:
+    """
+    Bounding box query
+
+    Test
+    """
+
+    def _fix_name(name: str | Iterable[str]):
+        return list(name) if isinstance(name, Iterable) and not isinstance(name, str) else [name]
+
+    # make all input iterables
+    labels_layer = _fix_name(labels_layer)
+    crd = _crd_to_iterable_of_iterables(crd)
+    to_coordinate_system = _fix_name(to_coordinate_system)
+    assert (
+        len(labels_layer) == len(crd) == len(to_coordinate_system)
+    ), "The number of 'labels_layer', 'crd' and 'to_coordinate_system' specified should all be equal."
+
+    region = []
+
+    sdata_queried = SpatialData()
+    # back resulting sdata to zarr store if output is specified
+    if output is not None:
+        sdata_queried.write(output)
+
+    # first add queried labels layer to sdata, so we do not have to query them + calculate unique labels in them len[*sdata.tables] times.
+    labels_ids = []
+    # labels_layer_queried=[]
+    for _labels_layer, _crd, _to_coordinate_system in zip(labels_layer, crd, to_coordinate_system):
+        se = _get_spatial_element(sdata, layer=_labels_layer)
+
+        if _crd is None:
+            se_queried = se
+        else:
+            se_queried = bounding_box_query_spatialdata(
+                se,
+                axes=("y", "x"),  # for now only support bounding box query in y and x via crd
+                min_coordinate=[_crd[2], _crd[0]],
+                max_coordinate=[_crd[3], _crd[1]],
+                target_coordinate_system=_to_coordinate_system,
+            )
+
+        if se_queried is None:
+            # set labels_id to empty array, so for this labels layer, all instances will be removed from table.
+            labels_ids.append(np.array([]))
+            log.warning(
+                f"query with crd {crd} to coordinate system {to_coordinate_system} for labels layer {labels_layer} resulted in empty labels layer."
+                f"Therefore labels layer {labels_layer} will not be present in resulting spatialdata object. "
+                f"Instances in tables annotated by {labels_layer} will also be removed from the tables."
+            )
+        else:
+            labels_ids.append(da.unique(se_queried.data).compute())
+            sdata_queried = add_labels_layer(
+                sdata_queried,
+                arr=se_queried.data.rechunk(
+                    se_queried.data.chunksize
+                ),  # rechunk to avoid irregular chunks when writing to zarr store.
+                output_layer=_labels_layer,
+                transformations=get_transformation(se_queried, get_all=True),
+                # note that if labels layer was multiscale, it will now not be multiscale.
+            )
+
+    # now query the associated table layer
+    for _table_layer in [*sdata.tables]:
+        adata = sdata.tables[_table_layer]
+        remove = np.ones(len(adata), dtype=bool)
+
+        for _labels_layer, _crd, _to_coordinate_system, _labels_id in zip(
+            labels_layer, crd, to_coordinate_system, labels_ids
+        ):
+            # the code also handles case when labels layer does not annotate the table
+            # (i.e. _labels_layer not in adata.obs[_REGION_KEY].values), because remove already set to True for all instances.
+            if _labels_layer in adata.obs[_REGION_KEY].values:
+                mask_label = adata.obs[_REGION_KEY] == _labels_layer
+
+                remove_label = ~((mask_label) & (adata.obs[_INSTANCE_KEY].isin(_labels_id))).to_numpy()
+                remove = remove & remove_label
+                if remove_label[
+                    (mask_label).to_numpy()
+                ].all():  # if all instances from this label layer will be removed from adata, then we do not append _labels_layer to region
+                    continue
+                else:
+                    region.append(_labels_layer)
+
+        if remove.all():
+            log.info(
+                f"Query removed all instances from table layer {_table_layer}. "
+                "Therefore this table layer will not be present in resulting spatialdata object."
+            )
+            continue
+        # subset
+        adata = adata[~remove].copy()
+        # add subsetted adata to sdata
+        sdata_queried = add_table_layer(
+            sdata_queried,
+            adata=adata,
+            output_layer=_table_layer,
+            region=region,
+        )
+
+    # now copy image, shapes and points layer if copy is True.
+    layers_to_copy = []
+
+    if copy_img_layer:
+        layers_to_copy.extend([*sdata.images])
+    if copy_shapes_layer:
+        layers_to_copy.extend([*sdata.shapes])
+    if copy_points_layer:
+        layers_to_copy.extend(*[sdata.points])
+
+    for _layer_to_copy in layers_to_copy:
+        sdata_queried[_layer_to_copy] = sdata[_layer_to_copy]
+        if sdata_queried.is_backed():
+            sdata_queried.write_element(_layer_to_copy)
+
+    # if backed, and if there were layers copied, we read back from zarr, otherwise sdata_queried not self contained
+    if sdata_queried.is_backed() and layers_to_copy:
+        sdata_queried = read_zarr(sdata_queried.path)
+
+    return sdata_queried
+
+
+def _crd_to_iterable_of_iterables(
+    crd: tuple[int, int, int, int] | Iterable[tuple[int, int, int, int] | None] | None,
+) -> Iterable[tuple[int, int, int, int]]:
+    _iterable_elements = False
+    if crd is not None:
+        for element in crd:
+            # check if any of the elements is iterable, if so, we are probably dealing with an Iterable of Iterables.
+            if (isinstance(element, Iterable) and not isinstance(element, str)) or element is None:
+                _iterable_elements = True
+                break
+
+    if not _iterable_elements:
+        crd = [crd]
+
+    return crd

--- a/src/sparrow/utils/_query.py
+++ b/src/sparrow/utils/_query.py
@@ -22,10 +22,10 @@ def bounding_box_query(
     crd: tuple[int, int, int, int]
     | Iterable[tuple[int, int, int, int] | None]
     | None,  # specifying None is usefull if you want to filter tables layers on specific labels layers (only keep the ones that are annotated)
-    output: str | Path | None = None,
-    copy_img_layer: bool = True,  # whether to copy all img layers to new spatialdata object or not.
+    copy_img_layer: bool = True,  # whether to copy all img layers to the new spatialdata object or not.
     copy_shapes_layer: bool = True,
     copy_points_layer: bool = True,
+    output: str | Path | None = None,  # path to zarr store, if the resulting spatialdata object needs to be backed.
 ) -> SpatialData:
     """
     Bounding box query
@@ -72,9 +72,9 @@ def bounding_box_query(
             # set labels_id to empty array, so for this labels layer, all instances will be removed from table.
             labels_ids.append(np.array([]))
             log.warning(
-                f"query with crd {crd} to coordinate system {to_coordinate_system} for labels layer {labels_layer} resulted in empty labels layer."
-                f"Therefore labels layer {labels_layer} will not be present in resulting spatialdata object. "
-                f"Instances in tables annotated by {labels_layer} will also be removed from the tables."
+                f"query with crd {crd} to coordinate system '{to_coordinate_system}' for labels layer '{labels_layer}' resulted in empty labels layer."
+                f"Therefore labels layer '{labels_layer}' will not be present in resulting spatialdata object. "
+                f"Instances in tables annotated by '{labels_layer}' will also be removed from the tables."
             )
         else:
             labels_ids.append(da.unique(se_queried.data).compute())
@@ -112,7 +112,7 @@ def bounding_box_query(
 
         if remove.all():
             log.info(
-                f"Query removed all instances from table layer {_table_layer}. "
+                f"Query removed all instances from table layer '{_table_layer}'. "
                 "Therefore this table layer will not be present in resulting spatialdata object."
             )
             continue


### PR DESCRIPTION
Support for bounding box query

`sp.utils.bounding_box_query`. 

Necessary, because spatialdata `bounding_box_query` did not allow for query wrt multiple coordinate systems that also allowed for filtering tables layer. 
Also points layer was pulled in memory via a compute in spatialdata.