### PR TITLE
SC_37 bump spatialdata

### DIFF
--- a/src/sparrow/image/_image.py
+++ b/src/sparrow/image/_image.py
@@ -4,13 +4,12 @@ import dask.array as da
 import numpy as np
 import xarray as xr
 from dask.array import Array
-from datatree import DataTree
 from spatialdata import SpatialData
 from spatialdata.models._utils import MappingToCoordinateSystem_t
 from spatialdata.models.models import ScaleFactors_t
 from spatialdata.transformations import get_transformation
 from spatialdata.transformations.transformations import Identity, Sequence, Translation
-from xarray import DataArray
+from xarray import DataArray, DataTree
 
 from sparrow.image._manager import ImageLayerManager, LabelLayerManager
 from sparrow.utils._transformations import _get_translation_values

--- a/src/sparrow/image/_manager.py
+++ b/src/sparrow/image/_manager.py
@@ -5,11 +5,10 @@ from typing import Any
 
 import spatialdata
 from dask.array import Array
-from datatree import DataTree
 from spatialdata import SpatialData, read_zarr
 from spatialdata.models._utils import MappingToCoordinateSystem_t
 from spatialdata.models.models import ScaleFactors_t
-from xarray import DataArray
+from xarray import DataArray, DataTree
 
 from sparrow.utils._io import _incremental_io_on_disk
 from sparrow.utils.pylogger import get_pylogger

--- a/src/sparrow/utils/_io.py
+++ b/src/sparrow/utils/_io.py
@@ -1,11 +1,12 @@
+from __future__ import annotations
+
 import uuid
 
 from anndata import AnnData
 from dask.dataframe import DataFrame
-from datatree import DataTree
 from geopandas import GeoDataFrame
 from spatialdata import SpatialData, read_zarr
-from xarray import DataArray
+from xarray import DataArray, DataTree
 
 from sparrow.utils.pylogger import get_pylogger
 

--- a/src/sparrow/utils/utils.py
+++ b/src/sparrow/utils/utils.py
@@ -7,7 +7,6 @@ from typing import Any
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
-from datatree import DataTree
 from geopandas import GeoDataFrame
 from omegaconf import OmegaConf
 from omegaconf.dictconfig import DictConfig
@@ -15,7 +14,7 @@ from shapely.affinity import translate
 from shapely.geometry import LineString, MultiLineString
 from spatialdata.models import get_axes_names
 from spatialdata.transformations import get_transformation
-from xarray import DataArray
+from xarray import DataArray, DataTree
 
 from sparrow.utils._transformations import _get_translation_values
 

--- a/src/sparrow/widgets/_clean_widget.py
+++ b/src/sparrow/widgets/_clean_widget.py
@@ -13,11 +13,11 @@ import napari.layers
 import napari.types
 import napari.utils
 import numpy as np
-from datatree import DataTree
 from magicgui import magic_factory
 from napari.qt.threading import thread_worker
 from napari.utils.notifications import show_info
 from spatialdata import SpatialData, read_zarr
+from xarray import DataTree
 
 from sparrow import utils as utils
 from sparrow.image._image import _get_translation

--- a/src/sparrow/widgets/_load_widget.py
+++ b/src/sparrow/widgets/_load_widget.py
@@ -8,13 +8,13 @@ import napari.layers
 import napari.types
 import napari.utils
 import numpy as np
-from datatree import DataTree
 from hydra import compose, initialize_config_dir
 from magicgui import magic_factory
 from napari.qt.threading import thread_worker
 from napari.utils.notifications import show_info
 from pkg_resources import resource_filename
 from spatialdata import SpatialData
+from xarray import DataTree
 
 from sparrow import utils
 from sparrow.image._image import _get_translation


### PR DESCRIPTION
- bump spatialdata was causing issues due to `from datatree import DataTree` was no longer available. Replaced with `from xarray import DataTree`