### PR TITLE
allow chunks none, threshold align labels

### DIFF
--- a/src/harpy/image/segmentation/_align_masks.py
+++ b/src/harpy/image/segmentation/_align_masks.py
@@ -15,8 +15,9 @@ def align_labels_layers(
     sdata: SpatialData,
     labels_layer_1: str,
     labels_layer_2: str,
+    threshold: float = 0.0,
     depth: tuple[int, int] | int = 100,
-    chunks: str | int | tuple[int, int] | None = "auto",
+    chunks: str | int | tuple[int, int] | None = None,
     output_labels_layer: str | None = None,
     output_shapes_layer: str | None = None,
     scale_factors: ScaleFactors_t | None = None,
@@ -42,13 +43,16 @@ def align_labels_layers(
         The name of the first labels layer to align.
     labels_layer_2
         The name of the second labels layer to align.
+    threshold
+        Minimum required overlap between a label in `labels_layer_1` and any label in `labels_layer_2`.
+        If the overlap fraction is less than this threshold, the label is set to 0 in `output_labels_layer`.
     depth
         The depth around the boundary of each block to load when the array is split into blocks
         (for alignment). This ensures that the split isn't causing misalignment along the edges.
         Default is 100. Please set depth>cell size to avoid chunking effects.
     chunks
         The desired chunk size for the Dask computation in 'y' and 'x', or "auto" to allow the function to
-        choose an optimal chunk size based on the data. Default is "auto".
+        choose an optimal chunk size based on the data.
     output_labels_layer
         The name for the new labels layer generated after alignment. If None and overwrite is False,
         a ValueError is raised. If None and overwrite is True, 'labels_layer_1' will be overwritten
@@ -86,9 +90,11 @@ def align_labels_layers(
     --------
     >>> sdata = align_labels_layers(sdata, 'layer_1', 'layer_2', depth=(50, 50), overwrite=True)
     """
+    assert 0 <= threshold <= 1, "Threshold must be between 0 and 1 (inclusive)."
     sdata = map_labels(
         sdata,
         func=_relabel_array_1_to_array_2_per_chunk,
+        threshold=threshold,
         labels_layers=[labels_layer_1, labels_layer_2],
         depth=depth,
         chunks=chunks,
@@ -104,7 +110,7 @@ def align_labels_layers(
     return sdata
 
 
-def _relabel_array_1_to_array_2_per_chunk(array_1: NDArray, array_2: NDArray) -> NDArray:
+def _relabel_array_1_to_array_2_per_chunk(array_1: NDArray, array_2: NDArray, threshold: float = 0.0) -> NDArray:
     assert array_1.shape == array_2.shape
 
     new_array = np.zeros((array_1.shape), dtype=int)
@@ -114,7 +120,8 @@ def _relabel_array_1_to_array_2_per_chunk(array_1: NDArray, array_2: NDArray) ->
         if label == 0:
             continue  # Skip label 0 as it represents the background
 
-        positions = np.where(array_1 == label)
+        mask_label_array_1 = array_1 == label
+        positions = np.where(mask_label_array_1)
 
         overlapping_labels = array_2[positions]
 
@@ -126,9 +133,12 @@ def _relabel_array_1_to_array_2_per_chunk(array_1: NDArray, array_2: NDArray) ->
         # Find the label with the maximum area
         if label_areas:
             max_label = max(label_areas, key=label_areas.get)
+            max_area = label_areas[max_label]
+            # Only set new label if the max_label covers more than threshold of overlap
+            if max_area / mask_label_array_1.sum() >= threshold:
+                new_array[positions] = max_label
+            else:
+                new_array[positions] = 0
         else:
-            max_label = 0  # Set to 0 if there's no overlap
-
-        new_array[positions] = max_label
-
+            new_array[positions] = 0  # set to zero if there is no overlap
     return new_array

--- a/src/harpy/image/segmentation/_expand_masks.py
+++ b/src/harpy/image/segmentation/_expand_masks.py
@@ -16,7 +16,7 @@ def expand_labels_layer(
     labels_layer: str,
     distance: int = 10,
     depth: tuple[int, int] | int = 100,
-    chunks: str | int | tuple[int, int] | None = "auto",
+    chunks: str | int | tuple[int, int] | None = None,
     output_labels_layer: str | None = None,
     output_shapes_layer: str | None = None,
     scale_factors: ScaleFactors_t | None = None,

--- a/src/harpy/image/segmentation/_filter_masks.py
+++ b/src/harpy/image/segmentation/_filter_masks.py
@@ -17,7 +17,7 @@ def filter_labels_layer(
     min_size: int = 10,
     max_size: int = 100000,
     depth: tuple[int, int] | int = 100,
-    chunks: str | int | tuple[int, int] | None = "auto",
+    chunks: str | int | tuple[int, int] | None = None,
     output_labels_layer: str | None = None,
     output_shapes_layer: str | None = None,
     scale_factors: ScaleFactors_t | None = None,
@@ -42,7 +42,7 @@ def filter_labels_layer(
         Default is 100. Please set depth>cell diameter to avoid chunking effects.
     chunks
         The desired chunk size for the Dask computation, or "auto" to allow the function to
-        choose an optimal chunk size based on the data. Default is "auto".
+        choose an optimal chunk size based on the data.
     output_labels_layer
         The name of the output labels layer where results will be stored. This must be specified.
     output_shapes_layer

--- a/src/harpy/image/segmentation/_map.py
+++ b/src/harpy/image/segmentation/_map.py
@@ -41,7 +41,7 @@ def map_labels(
     output_labels_layer: str | None = None,
     output_shapes_layer: str | None = None,
     depth: tuple[int, int] | int = 100,
-    chunks: str | int | tuple[int, int] | None = "auto",
+    chunks: str | int | tuple[int, int] | None = None,
     scale_factors: ScaleFactors_t | None = None,
     overwrite: bool = False,
     relabel_chunks: bool = True,

--- a/src/harpy/image/segmentation/_merge_masks.py
+++ b/src/harpy/image/segmentation/_merge_masks.py
@@ -24,7 +24,7 @@ def merge_labels_layers(
     labels_layer_2: str,
     threshold: float = 0.5,
     depth: tuple[int, int] | int = 100,
-    chunks: str | int | tuple[int, int] | None = "auto",
+    chunks: str | int | tuple[int, int] | None = None,
     output_labels_layer: str | None = None,
     output_shapes_layer: str | None = None,
     scale_factors: ScaleFactors_t | None = None,
@@ -112,7 +112,7 @@ def merge_labels_layers_nuclei(
     labels_layer_nuclei: str,
     threshold: float = 0.5,
     depth: tuple[int, int] | int = 100,
-    chunks: str | int | tuple[int, int] | None = "auto",
+    chunks: str | int | tuple[int, int] | None = None,
     output_labels_layer: str | None = None,
     output_shapes_layer: str | None = None,
     scale_factors: ScaleFactors_t | None = None,
@@ -285,7 +285,7 @@ def mask_to_original(
     labels_layer: str,
     original_labels_layers: list[str],
     depth: tuple[int, int] | int = 400,
-    chunks: str | int | tuple[int, int] | None = "auto",
+    chunks: str | int | tuple[int, int] | None = None,
 ) -> DataFrame:
     """
     Map to original.

--- a/src/harpy/image/segmentation/_segmentation.py
+++ b/src/harpy/image/segmentation/_segmentation.py
@@ -58,7 +58,7 @@ def segment(
     output_shapes_layer: str | list[str] | None = "segmentation_mask_boundaries",
     labels_layer_align: str | None = None,
     depth: tuple[int, int] | int = 100,
-    chunks: str | int | tuple[int, int] | None = "auto",
+    chunks: str | int | tuple[int, int] | None = None,
     boundary: str = "reflect",
     trim: bool = False,
     iou: bool = True,
@@ -176,7 +176,7 @@ def segment_points(
     output_shapes_layer: str | list[str] | None = "segmentation_mask_boundaries",
     labels_layer_align: str | None = None,
     depth: tuple[int, int] | int = 100,
-    chunks: str | int | tuple[int, int] | None = "auto",
+    chunks: str | int | tuple[int, int] | None = None,
     boundary: str = "reflect",
     trim: bool = False,
     iou: bool = True,
@@ -450,7 +450,7 @@ class SegmentationModel(ABC):
                         depth[2],
                     ),
                     chunks=chunks
-                    if isinstance(chunks, str)
+                    if isinstance(chunks, str | type(None))
                     else (chunks[1], chunks[2]),  # get this from kwargs. Make a copy of kwargs before it is popped
                     iou_depth=(iou_depth[1], iou_depth[2]),
                     iou_threshold=kwargs["iou_threshold"],

--- a/src/harpy/image/segmentation/_utils.py
+++ b/src/harpy/image/segmentation/_utils.py
@@ -22,7 +22,7 @@ _SEG_DTYPE = np.uint32
 def _rechunk_overlap(
     x: Array,
     depth: dict[int, int],
-    chunks: str | int | tuple[int, ...] | None = "auto",
+    chunks: str | int | tuple[int, ...] | None = None,
 ) -> Array:
     # rechunk, so that we ensure minimum overlap
 


### PR DESCRIPTION
- Bug fix when chunks=None in hp.im.segment, and labels_layer_align is not None.
- support for threshold in hp.im.align_labels_layer