### PR TITLE
Setting get_spatialdata_registry() known hash to None

### DIFF
--- a/src/harpy/datasets/registry.py
+++ b/src/harpy/datasets/registry.py
@@ -76,7 +76,7 @@ def get_spatialdata_registry(path: str | Path | None = None) -> Pooch:
         base_url="https://s3.embl.de/spatialdata",
         version=__version__,
         registry={
-            "spatialdata-sandbox/steinbock_io.zip": "e5eac7dbe316ad7008822fde95c1abacfcfc771b8f9ab28c0e6f768d293cd8d5",
+            "spatialdata-sandbox/steinbock_io.zip": None,
         },
     )
     return registry


### PR DESCRIPTION
modified:   src/harpy/datasets/registry.py to set known hash in `get_spatialdata_registry()` definition to `None` from e5eac7dbe316ad7008822fde95c1abacfcfc771b8f9ab28c0e6f768d293cd8d5. Closes #125. @berombau 