### PR TITLE
visium wrapper around spatialdata-io reader

### DIFF
--- a/src/harpy/io/_visium.py
+++ b/src/harpy/io/_visium.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from pathlib import Path
+import harpy as hp
+import pandas as pd
+import geopandas as gpd
+
+from spatialdata import SpatialData, read_zarr
+from spatialdata.models import TableModel
+from spatialdata_io._constants._constants import VisiumKeys
+from spatialdata_io.readers.visium import visium as sdata_visium
+
+from harpy.utils._keys import _INSTANCE_KEY, _REGION_KEY
+
+
+def visium(
+    path: str | Path,
+    dataset_id: str | None = None,
+    counts_file: str = VisiumKeys.FILTERED_COUNTS_FILE,
+    output: str | Path | None = None,
+) -> SpatialData:
+    """
+    Read *10x Genomics* Visium formatted dataset.
+
+    Wrapper around `spatialdata.io.readers.visium.visium`, but with the resulting table annotated by a labels layer.
+
+    .. see also::
+
+        - `Space Ranger output <https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/overview>`_.
+
+    Parameters
+    ----------
+    path
+        Path to directory containing the *10x Genomics* Visium output.
+    dataset_id
+        Unique identifier of the dataset. If `None`, it tries to infer it from the file name of the feature slice file.
+    counts_file
+        Name of the counts file, defaults to `'filtered_feature_bc_matrix.h5'`; a common alternative is
+        `'raw_feature_bc_matrix.h5'`.
+    output
+        The path where the resulting `SpatialData` object will be backed. If None, it will not be backed to a zarr store.
+    """
+    sdata = sdata_visium(
+        path=path,
+        dataset_id=dataset_id,
+        counts_file=counts_file,
+    )
+
+    for table_layer in [*sdata.tables]:
+        adata = sdata[table_layer]
+        adata.var_names_make_unique()
+        adata.X = adata.X.tocsc()
+
+        _old_instance_key = sdata[table_layer].uns[TableModel.ATTRS_KEY][TableModel.INSTANCE_KEY]
+        _old_region_key = sdata[table_layer].uns[TableModel.ATTRS_KEY][TableModel.REGION_KEY_KEY]
+        adata.obs[_REGION_KEY] = pd.Categorical(adata.obs[_old_region_key].astype(str) + '_labels')
+        if adata.obs[_old_instance_key].astype(int).min() == 0: # Make sure index starts from 1
+            adata.obs[_INSTANCE_KEY] = adata.obs[_old_instance_key].astype(int) + 1
+        else:
+            adata.obs[_INSTANCE_KEY] = adata.obs[_old_instance_key].astype(int)
+
+        adata.uns.pop(TableModel.ATTRS_KEY)
+        adata = TableModel.parse(
+            adata,
+            region_key=_REGION_KEY,
+            region=adata.obs[_REGION_KEY].cat.categories.to_list(),
+            instance_key=_INSTANCE_KEY,
+        )
+
+        assert (
+            len(sdata.shapes[dataset_id]) == len(adata)
+        ), f"Shapes layer '{dataset_id}' and corresponding table '{table_layer}' should have same length."
+
+        sdata.shapes[dataset_id].index = (
+            adata.obs.set_index(_old_instance_key).loc[sdata.shapes[dataset_id].index, _INSTANCE_KEY].values
+        )
+        sdata.shapes[dataset_id].index.name = _INSTANCE_KEY
+
+        if _old_region_key in adata.obs.columns:
+            adata.obs.drop(columns=_old_region_key, inplace=True)
+            
+        if _old_instance_key in adata.obs.columns:
+            adata.obs.drop(columns=_old_instance_key, inplace=True)
+            
+        # Convert Points to Polygons
+        if 'radius' not in sdata.shapes[dataset_id].columns:
+            raise ValueError("Shapes layer is missing 'radius' column required for polygon buffering.")
+
+        radius = sdata.shapes[dataset_id]['radius'].mean()
+        polygons = sdata.shapes[dataset_id].buffer(radius, cap_style="round")
+        sdata = hp.sh.add_shapes_layer(sdata, gpd.GeoDataFrame(geometry=polygons), output_layer=dataset_id, overwrite=True)
+        
+        # Create labels layer
+        sdata = hp.im.rasterize(
+            sdata,
+            shapes_layer = dataset_id,
+            output_layer = f'{dataset_id}_labels',
+            chunks = 5000,
+            overwrite = True,
+        )
+
+        del sdata[table_layer]
+
+        sdata[table_layer] = adata
+
+    if output is not None:
+        sdata.write(output)
+        sdata = read_zarr(sdata.path)
+
+    return sdata

--- a/src/harpy/io/_visium.py
+++ b/src/harpy/io/_visium.py
@@ -17,6 +17,7 @@ def visium(
     path: str | Path,
     dataset_id: str | None = None,
     counts_file: str = VisiumKeys.FILTERED_COUNTS_FILE,
+    fullres_image_file: str | Path | None = None,
     output: str | Path | None = None,
 ) -> SpatialData:
     """
@@ -37,6 +38,8 @@ def visium(
     counts_file
         Name of the counts file, defaults to `'filtered_feature_bc_matrix.h5'`; a common alternative is
         `'raw_feature_bc_matrix.h5'`.
+    fullres_image_file
+        Path to the full-resolution image.
     output
         The path where the resulting `SpatialData` object will be backed. If None, it will not be backed to a zarr store.
     """
@@ -44,6 +47,7 @@ def visium(
         path=path,
         dataset_id=dataset_id,
         counts_file=counts_file,
+        fullres_image_file=fullres_image_file,
     )
 
     for table_layer in [*sdata.tables]:

--- a/src/harpy/io/_visium_hd.py
+++ b/src/harpy/io/_visium_hd.py
@@ -4,9 +4,9 @@ from pathlib import Path
 
 from spatialdata import SpatialData, read_zarr
 from spatialdata.models import TableModel
+from spatialdata.transformations import get_transformation, remove_transformation, set_transformation
 from spatialdata_io._constants._constants import VisiumHDKeys
 from spatialdata_io.readers.visium_hd import visium_hd as sdata_visium_hd
-from spatialdata.transformations import set_transformation, get_transformation, remove_transformation
 
 from harpy.utils._keys import _INSTANCE_KEY, _REGION_KEY
 
@@ -62,17 +62,21 @@ def visium_hd(
         load_all_images=load_all_images,
         bins_as_squares=bins_as_squares,
     )
-    
-    if fullres_image_file is not None: # Move full image from global to dataset_id coordinate system
+
+    if fullres_image_file is not None:  # Move full image from global to dataset_id coordinate system
         transformations = get_transformation(sdata.images[f"{dataset_id}_full_image"], get_all=True)
-        set_transformation(sdata.images[f"{dataset_id}_full_image"], transformations['global'], to_coordinate_system=dataset_id)
+        set_transformation(
+            sdata.images[f"{dataset_id}_full_image"], transformations["global"], to_coordinate_system=dataset_id
+        )
         remove_transformation(sdata.images[f"{dataset_id}_full_image"], to_coordinate_system="global")
 
-    if load_all_images: # Move cytassist image from global to dataset_id coordinate system
+    if load_all_images:  # Move cytassist image from global to dataset_id coordinate system
         transformations = get_transformation(sdata.images[f"{dataset_id}_cytassist_image"], get_all=True)
-        set_transformation(sdata.images[f"{dataset_id}_cytassist_image"], transformations['global'], to_coordinate_system=dataset_id)
+        set_transformation(
+            sdata.images[f"{dataset_id}_cytassist_image"], transformations["global"], to_coordinate_system=dataset_id
+        )
         remove_transformation(sdata.images[f"{dataset_id}_cytassist_image"], to_coordinate_system="global")
-        
+
     for table_layer in [*sdata.tables]:
         adata = sdata[table_layer]
         adata.var_names_make_unique()
@@ -101,11 +105,10 @@ def visium_hd(
         if VisiumHDKeys.INSTANCE_KEY in adata.obs.columns:
             adata.obs.drop(columns=VisiumHDKeys.INSTANCE_KEY, inplace=True)
         sdata[shapes_layer].index.name = _INSTANCE_KEY
-        
+
         del sdata[table_layer]
 
         sdata[table_layer] = adata
-
 
     if output is not None:
         sdata.write(output)

--- a/src/harpy/io/_visium_hd.py
+++ b/src/harpy/io/_visium_hd.py
@@ -6,6 +6,7 @@ from spatialdata import SpatialData, read_zarr
 from spatialdata.models import TableModel
 from spatialdata_io._constants._constants import VisiumHDKeys
 from spatialdata_io.readers.visium_hd import visium_hd as sdata_visium_hd
+from spatialdata.transformations import set_transformation, get_transformation, remove_transformation
 
 from harpy.utils._keys import _INSTANCE_KEY, _REGION_KEY
 
@@ -13,8 +14,11 @@ from harpy.utils._keys import _INSTANCE_KEY, _REGION_KEY
 def visium_hd(
     path: str | Path,
     dataset_id: str | None = None,
+    filtered_counts_file: bool = True,
     bin_size: int | list[int] | None = None,
     bins_as_squares: bool = True,
+    fullres_image_file: str | Path | None = None,
+    load_all_images: bool = False,
     output: str | Path | None = None,
 ) -> SpatialData:
     """
@@ -22,7 +26,7 @@ def visium_hd(
 
     Wrapper around `spatialdata.io.readers.visium_hd.visium_hd`, but with the resulting table annotated by a labels layer.
 
-    .. seealso::
+    .. see also::
 
         - `Space Ranger output <https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/overview>`_.
 
@@ -32,24 +36,43 @@ def visium_hd(
         Path to directory containing the *10x Genomics* Visium HD output.
     dataset_id
         Unique identifier of the dataset. If `None`, it tries to infer it from the file name of the feature slice file.
+    filtered_counts_file
+        Uses 'filtered_feature_bc_matrix.h5' (when True) or to 'raw_feature_bc_matrix.h5' (when False).
     bin_size
         When specified, load the data of a specific bin size, or a list of bin sizes. By default, it loads all the
         available bin sizes.
     bins_as_squares
         If `True`, the bins are represented as squares. If `False`, the bins are represented as circles. For a correct
         visualization one should use squares.
+    fullres_image_file
+        Path to the full-resolution image.
+    load_all_images
+        If `False`, load only the full resolution, high resolution and low resolution images. If `True`, also the
+        following images: `cytassist_image.tiff`.
     output
         The path where the resulting `SpatialData` object will be backed. If None, it will not be backed to a zarr store.
     """
     sdata = sdata_visium_hd(
         path=path,
-        bin_size=bin_size,
         dataset_id=dataset_id,
-        filtered_counts_file=True,
+        filtered_counts_file=filtered_counts_file,
+        bin_size=bin_size,
         annotate_table_by_labels=True,
+        fullres_image_file=fullres_image_file,
+        load_all_images=load_all_images,
         bins_as_squares=bins_as_squares,
     )
+    
+    if fullres_image_file is not None: # Move full image from global to dataset_id coordinate system
+        transformations = get_transformation(sdata.images[f"{dataset_id}_full_image"], get_all=True)
+        set_transformation(sdata.images[f"{dataset_id}_full_image"], transformations['global'], to_coordinate_system=dataset_id)
+        remove_transformation(sdata.images[f"{dataset_id}_full_image"], to_coordinate_system="global")
 
+    if load_all_images: # Move cytassist image from global to dataset_id coordinate system
+        transformations = get_transformation(sdata.images[f"{dataset_id}_cytassist_image"], get_all=True)
+        set_transformation(sdata.images[f"{dataset_id}_cytassist_image"], transformations['global'], to_coordinate_system=dataset_id)
+        remove_transformation(sdata.images[f"{dataset_id}_cytassist_image"], to_coordinate_system="global")
+        
     for table_layer in [*sdata.tables]:
         adata = sdata[table_layer]
         adata.var_names_make_unique()
@@ -78,10 +101,11 @@ def visium_hd(
         if VisiumHDKeys.INSTANCE_KEY in adata.obs.columns:
             adata.obs.drop(columns=VisiumHDKeys.INSTANCE_KEY, inplace=True)
         sdata[shapes_layer].index.name = _INSTANCE_KEY
-
+        
         del sdata[table_layer]
 
         sdata[table_layer] = adata
+
 
     if output is not None:
         sdata.write(output)


### PR DESCRIPTION
This PR add a wrapper function around spatialdata.io.readers.visium.visium with the option of reading in the fullres microscopy image.

The PR also updates the visium_hd wrapper so that it takes 'filtered_counts_file', 'fullres_image_file' and 'load_all_images' and passes them on to the spatialdata-io visium_hd reader. Note that spatialdata-io places the full image and cystassist image in the 'global' coordinate system, while all other data is placed in the dataset-id coordinate system. This results in, for example, issues when plotting (tested with spatialdata-plot) and does not seem like the desired behavior. A fix was added here, but it should probably be addressed in the spatialdata-io visium_hd reader itself.