### PR TITLE
added region_annotations

### DIFF
--- a/src/harpy/shape/__init__.pyi
+++ b/src/harpy/shape/__init__.pyi
@@ -1,6 +1,11 @@
 from ._cell_expansion import create_voronoi_boundaries
-from ._shape import add_shapes_layer, filter_shapes_layer, intersect_rectangles, vectorize, prep_region_annotations
-from ._filters import morphological_features, filter_shapes_numerical, filter_shapes_categorical, filter_shapes_by_shapes
+from ._filters import (
+    filter_shapes_by_shapes,
+    filter_shapes_categorical,
+    filter_shapes_numerical,
+    morphological_features,
+)
+from ._shape import add_shapes_layer, filter_shapes_layer, intersect_rectangles, prep_region_annotations, vectorize
 
 __all__ = [
     "add_shapes_layer",

--- a/src/harpy/shape/_shape.py
+++ b/src/harpy/shape/_shape.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
+import numpy as np
 from dask.array import Array
 from geopandas import GeoDataFrame
-from shapely.geometry import GeometryCollection, MultiPolygon, Polygon, Point, MultiPoint, LineString, MultiLineString
+from shapely.geometry import GeometryCollection, MultiPolygon, Point, Polygon
 from spatialdata import SpatialData
 from spatialdata.models._utils import MappingToCoordinateSystem_t
 from spatialdata.transformations import get_transformation
 
 from harpy.image._image import _get_spatial_element
 from harpy.shape._manager import ShapesLayerManager
-
-import numpy as np
-
 from harpy.utils.pylogger import get_pylogger
+
 log = get_pylogger(__name__)
+
 
 def vectorize(
     sdata,
@@ -184,7 +184,7 @@ def intersect_rectangles(rect1: list[int | float], rect2: list[int | float]) -> 
     else:
         return None
 
-    
+
 def prep_region_annotations(
     sdata: SpatialData,
     shapes_layer: str,
@@ -218,38 +218,37 @@ def prep_region_annotations(
     unnamed
         Name to be assigned to any unnamed geometries in `shape_names_column`. Defaults to 'unnamed'.
     unique_shape_names_column
-        Column name in which unique names will be created for single polygons by appending a counter to the original name in `shape_names_column` for polygons with the same name. Note 
-        that multipolygons will be split in individual polygons and each will get a unique name based on the original name of the multipolygon. Unique names will be stored in 
+        Column name in which unique names will be created for single polygons by appending a counter to the original name in `shape_names_column` for polygons with the same name. Note
+        that multipolygons will be split in individual polygons and each will get a unique name based on the original name of the multipolygon. Unique names will be stored in
         `{shape_names_column}-unique` in the updated shapes layer.
     erosion
-        Number of pixels to erode polygons by. This can avoid problems with overlapping edges of geometries when calculating distances. Default is 0.5 (i.e. erosion by 0.5 pixels).    
+        Number of pixels to erode polygons by. This can avoid problems with overlapping edges of geometries when calculating distances. Default is 0.5 (i.e. erosion by 0.5 pixels).
     overwrite
         If True, overwrites the `output_shapes_layer` if it already exists in `sdata`.
-        
+
     Returns
     -------
     Modified `sdata` object with updated updated shapes layer.
     """
-    
     # Create copy of shapes layer
     gdf = sdata.shapes[shapes_layer].copy()
     log.info(f"Found {len(gdf)} geometries in {shapes_layer}.")
-    
+
     # Ensure shape_names_column exist
     if shape_names_column not in gdf.columns:
         gdf[shape_names_column] = unnamed
-        
+
     gdf[shape_names_column] = gdf[shape_names_column].fillna("").astype(str)
     unnamed_mask = gdf[shape_names_column] == ""
-    for i, idx in enumerate(gdf[unnamed_mask].index):
+    for _i, idx in enumerate(gdf[unnamed_mask].index):
         gdf.at[idx, shape_names_column] = unnamed
-    
+
     # Convert Points with a radius column to circular polygons
     def _point_to_circle(geom, radius=None):
         if isinstance(geom, Point) and radius is not None:
             return geom.buffer(radius, resolution=16)
         return geom
-    
+
     if "radius" in gdf.columns:
         mask_points_with_radius = gdf.geometry.geom_type.eq("Point") & gdf["radius"].notna()
         n_converted = mask_points_with_radius.sum()
@@ -257,44 +256,43 @@ def prep_region_annotations(
         if n_converted > 0:
             log.info(f"Converting {n_converted} Point geometries with 'radius' to circular polygons.")
             gdf.loc[mask_points_with_radius, "geometry"] = gdf.loc[mask_points_with_radius].apply(
-                lambda row: _point_to_circle(row.geometry, getattr(row, "radius", None)),
-                axis=1
+                lambda row: _point_to_circle(row.geometry, getattr(row, "radius", None)), axis=1
             )
-        
+
     # Slightly erode all polygons (this avoids any shared borders between polygons)
     gdf["geometry"] = gdf.geometry.apply(
-        lambda geom: geom.buffer(
-            -erosion, 
-            join_style=2, 
-            resolution=16)
-        if geom.geom_type in ["Polygon", "MultiPolygon"] else geom
+        lambda geom: geom.buffer(-erosion, join_style=2, resolution=16)
+        if geom.geom_type in ["Polygon", "MultiPolygon"]
+        else geom
     )
-    polygon_mask = ~gdf.geometry.is_empty 
-    removed = len(gdf) - polygon_mask.sum() 
-    gdf = gdf[polygon_mask] # drop any polygons that collapsed to empty 
-    if removed > 0: 
+    polygon_mask = ~gdf.geometry.is_empty
+    removed = len(gdf) - polygon_mask.sum()
+    gdf = gdf[polygon_mask]  # drop any polygons that collapsed to empty
+    if removed > 0:
         log.info(f"Removed {removed} polygons that collapsed to empty after erosion.")
-        
+
     # Explode multipolygons into single polygons (this allows us to treat multipolygons as unique polygons)
     n_multipolygons = gdf.geometry.apply(lambda g: g.geom_type == "MultiPolygon").sum()
     gdf = gdf.explode(index_parts=False).reset_index(drop=True)
     n_after = len(gdf)
-    log.info(f"Split {n_multipolygons} multipolygons into individual polygons. Total number of geometries after splitting multipolgons is {n_after}.")
-    
+    log.info(
+        f"Split {n_multipolygons} multipolygons into individual polygons. Total number of geometries after splitting multipolgons is {n_after}."
+    )
+
     # Create unique names
     sizes = gdf.groupby(shape_names_column)[shape_names_column].transform("size")
     counter = gdf.groupby(shape_names_column).cumcount() + 1
     gdf[unique_shape_names_column] = np.where(
-        sizes.eq(1),
-        gdf[shape_names_column],
-        gdf[shape_names_column] + counter.astype(str)
+        sizes.eq(1), gdf[shape_names_column], gdf[shape_names_column] + counter.astype(str)
     )
-    
+
     # Avoid index 0
     if 0 in gdf.index:
-        log.warning("Index 0 found in shapes layer — shifting all indices by +1 since index 0 is reserved for background in labels layers.")
+        log.warning(
+            "Index 0 found in shapes layer — shifting all indices by +1 since index 0 is reserved for background in labels layers."
+        )
         gdf.index = gdf.index + 1
-    
+
     # sanity check. If this sanity check would fail in spatialdata at some point, then pass transformation to transformations parameter of add_shapes_layer.
     assert get_transformation(gdf, get_all=True) == get_transformation(sdata[shapes_layer], get_all=True)
 
@@ -307,4 +305,3 @@ def prep_region_annotations(
     )
 
     return sdata
-        

--- a/src/harpy/table/__init__.pyi
+++ b/src/harpy/table/__init__.pyi
@@ -4,14 +4,14 @@ from ._annotation import cluster_cleanliness, score_genes, score_genes_iter
 from ._clustering import kmeans, leiden
 from ._enrichment import nhood_enrichment
 from ._preprocess import preprocess_proteomics, preprocess_transcriptomics
+from ._region_annotations import assign_cells_to_shapes, compute_distance_to_shapes
 from ._regionprops import add_regionprop_features
-from ._table import add_table_layer, correct_marker_genes, filter_on_size, filter_numerical, filter_categorical
+from ._table import add_table_layer, correct_marker_genes, filter_categorical, filter_numerical, filter_on_size
 from .cell_clustering._clustering import flowsom
 from .cell_clustering._preprocess import cell_clustering_preprocess
 from .cell_clustering._weighted_channel_expression import weighted_channel_expression
 from .pixel_clustering._cluster_intensity import cluster_intensity
 from .pixel_clustering._neighbors import spatial_pixel_neighbors
-from ._region_annotations import assign_cells_to_shapes, compute_distance_to_shapes
 
 __all__ = [
     "add_table_layer",

--- a/src/harpy/table/_region_annotations.py
+++ b/src/harpy/table/_region_annotations.py
@@ -1,13 +1,16 @@
-from spatialdata import SpatialData
+from typing import Literal
+
 import geopandas as gpd
 import pandas as pd
-from typing import Literal
-from shapely.geometry import Polygon, MultiPolygon, Point, MultiPoint, LineString, MultiLineString
-from harpy.table._table import add_table_layer
-from harpy.utils._keys import _REGION_KEY, _INSTANCE_KEY
+from shapely.geometry import LineString, MultiLineString, MultiPolygon, Point, Polygon
+from spatialdata import SpatialData
 
+from harpy.table._table import add_table_layer
+from harpy.utils._keys import _REGION_KEY
 from harpy.utils.pylogger import get_pylogger
+
 log = get_pylogger(__name__)
+
 
 def assign_cells_to_shapes(
     sdata: SpatialData,
@@ -20,7 +23,7 @@ def assign_cells_to_shapes(
     mode: Literal["original_names", "unique_names", "both"] = "original_names",
     create_column_per_shape: bool = False,
     overlap_tolerance: float = 0.1,
-    spatial_key: str = 'spatial',
+    spatial_key: str = "spatial",
     xy_columns: tuple = None,
     overwrite: bool = False,
 ):
@@ -33,7 +36,7 @@ def assign_cells_to_shapes(
         The SpatialData object containing the input table layer and shapes layer.
     shapes_layer
         The shapes layer in `sdata.shapes` to use as input.
-    table_layer 
+    table_layer
         The table layer in `sdata.tables` to use as input.
     output_table_layer
         The output table layer in `sdata.tables` to which the updated table layer will be written.
@@ -57,25 +60,24 @@ def assign_cells_to_shapes(
         Key in `sdata.tables[table_layer].obsm` containing spatial coordinates. Ignored if `xy_columns` is provided.
     xy_columns
         Tuple of column names in `sdata.tables[table_layer].obs` containing the x and y coordinates the cells.
-        If None, defaults to using coordinates from `sdata.tables[table_layer].obsm[spatial_key]`. 
+        If None, defaults to using coordinates from `sdata.tables[table_layer].obsm[spatial_key]`.
     overwrite
         If True, overwrites the `output_table_layer` and/or `output_shapes_layer` if it already exists in `sdata`.
-    
+
     Notes
-    -------
-    - Only `Polygon` and `MultiPolygon` geometries are supported. Non-polygon geometries (e.g., `Point`, `LineString`) are skipped.    
-    
+    -----
+    - Only `Polygon` and `MultiPolygon` geometries are supported. Non-polygon geometries (e.g., `Point`, `LineString`) are skipped.
+
     Returns
     -------
     Modified `sdata` object with updated table layer.
     """
-    
     if not output_column and not create_column_per_shape:
         raise ValueError("Specify `output_column` or set `create_column_per_shape=True`.")
-    
+
     # Create copy of shapes layer
     gdf = sdata.shapes[shapes_layer].copy()
-    
+
     # Create copy of table layer
     adata = sdata.tables[table_layer].copy()
 
@@ -84,19 +86,25 @@ def assign_cells_to_shapes(
     skipped = len(gdf) - supported_mask.sum()
     if skipped > 0:
         log.info(f"Skipped {skipped} non-polygon geometries in {shapes_layer}.")
-    if skipped == len(gdf):  
-        log.warning(f"No supported geometries (Polygon, MultiPolygon) found. Skipping addition of table layer '{output_table_layer}' to sdata.")
+    if skipped == len(gdf):
+        log.warning(
+            f"No supported geometries (Polygon, MultiPolygon) found. Skipping addition of table layer '{output_table_layer}' to sdata."
+        )
         return sdata
-    
+
     gdf = gdf[supported_mask].copy().reset_index(drop=True)
 
     # Check for overlapping polygons
     total_area = gdf.geometry.area.sum()
     union_area = gdf.geometry.unary_union.area
     if total_area - union_area > overlap_tolerance and not create_column_per_shape:
-        raise ValueError(f"Overlapping polygons detected in {shapes_layer}. Correct polygons or use create_column_per_shape.")
+        raise ValueError(
+            f"Overlapping polygons detected in {shapes_layer}. Correct polygons or use create_column_per_shape."
+        )
     elif total_area - union_area > 0 and not create_column_per_shape:
-        log.warning(f"Overlaps detected (Δ={total_area - union_area:.3f}), below tolerance threshold {overlap_tolerance}.")
+        log.warning(
+            f"Overlaps detected (Δ={total_area - union_area:.3f}), below tolerance threshold {overlap_tolerance}."
+        )
 
     # Get cell coordinates
     if xy_columns is not None:
@@ -104,8 +112,7 @@ def assign_cells_to_shapes(
         coords = adata.obs[[x_col, y_col]].to_numpy()
     else:
         if spatial_key not in adata.obsm:
-            raise KeyError(
-                f"No spatial coordinates found in `obsm['{spatial_key}']` and `xy_columns` not provided.")
+            raise KeyError(f"No spatial coordinates found in `obsm['{spatial_key}']` and `xy_columns` not provided.")
         coords = adata.obsm[spatial_key]
         if coords.shape[1] != 2:
             raise ValueError(f"`obsm['{spatial_key}']` must have shape (n_cells, 2).")
@@ -113,19 +120,19 @@ def assign_cells_to_shapes(
     # Function to assign cell to a polygon
     def _assign_region(x, y, gdf, column, sindex):
         point = Point(x, y)
-        
+
         # Quick bounding box search to prefilter the cells
         candidate_idx = list(sindex.intersection(point.bounds))
         if not candidate_idx:
             return None
-        
+
         # Slower point‑in‑polygon search
         candidate_gdf = gdf.iloc[candidate_idx]
         match = candidate_gdf[candidate_gdf.contains(point)]
-        
+
         if match.empty:
             return None
-        
+
         return match[column].iloc[0]
 
     # Assign cells to polygons
@@ -152,10 +159,8 @@ def assign_cells_to_shapes(
             if gdf_shape.empty:
                 continue
 
-            sidx_shape = gdf_shape.sindex # Build spatial index
-            assigned = [
-                _assign_region(x, y, gdf_shape, name_column, sidx_shape) for x, y in coords
-            ]
+            sidx_shape = gdf_shape.sindex  # Build spatial index
+            assigned = [_assign_region(x, y, gdf_shape, name_column, sidx_shape) for x, y in coords]
             adata.obs[col_name] = assigned
 
     else:
@@ -168,23 +173,21 @@ def assign_cells_to_shapes(
 
         for output_column_name, name_column in run_assign_dict.items():
             # Assign one shape name per cell (to be avoided with overlapping regions)
-            sidx = gdf.sindex # Build spatial index
-            assigned = [
-                _assign_region(x, y, gdf, name_column, sidx)
-                for x, y in coords
-            ]
+            sidx = gdf.sindex  # Build spatial index
+            assigned = [_assign_region(x, y, gdf, name_column, sidx) for x, y in coords]
             adata.obs[output_column_name] = assigned
 
-    # Add table layer  
+    # Add table layer
     sdata = add_table_layer(
         sdata,
-        adata = adata,
-        output_layer = output_table_layer,
-        region = adata.obs[_REGION_KEY].cat.categories.to_list(),
-        overwrite = overwrite,
+        adata=adata,
+        output_layer=output_table_layer,
+        region=adata.obs[_REGION_KEY].cat.categories.to_list(),
+        overwrite=overwrite,
     )
-    
+
     return sdata
+
 
 def compute_distance_to_shapes(
     sdata: SpatialData,
@@ -195,14 +198,27 @@ def compute_distance_to_shapes(
     unique_shape_names_column: str = "name-unique",
     output_name: str = None,
     pixel_size_um: float = 1.0,
-    modes: list[Literal[
-        "nearest_edge", "nearest_edge_grouped", "all_edges",
-        "nearest_outer_edge", "nearest_outer_edge_grouped", "all_outer_edges",
-        "nearest_inner_edge", "nearest_inner_edge_grouped", "nearest_inner_edge_grouped_unique", "all_inner_edges",
-        "nearest_centroid", "nearest_centroid_grouped", "all_centroids",
-        "nearest_point", "nearest_point_grouped", "all_points"
-    ]] = ["all_edges"],
-    spatial_key: str = 'spatial',
+    modes: list[
+        Literal[
+            "nearest_edge",
+            "nearest_edge_grouped",
+            "all_edges",
+            "nearest_outer_edge",
+            "nearest_outer_edge_grouped",
+            "all_outer_edges",
+            "nearest_inner_edge",
+            "nearest_inner_edge_grouped",
+            "nearest_inner_edge_grouped_unique",
+            "all_inner_edges",
+            "nearest_centroid",
+            "nearest_centroid_grouped",
+            "all_centroids",
+            "nearest_point",
+            "nearest_point_grouped",
+            "all_points",
+        ]
+    ] = None,
+    spatial_key: str = "spatial",
     xy_columns: tuple = None,
     overwrite: bool = False,
 ):
@@ -216,7 +232,7 @@ def compute_distance_to_shapes(
         The SpatialData object containing the input table layer and shapes layer.
     shapes_layer
         The shapes layer in `sdata.shapes` to use as input.
-    table_layer 
+    table_layer
         The table layer in `sdata.tables` to use as input.
     output_table_layer
         The output table layer in `sdata.tables` to which the updated table layer will be written.
@@ -232,39 +248,39 @@ def compute_distance_to_shapes(
         Which distance features to calculate. Options include:
 
         Edge distances (For Polygon and MultiPolygon geometries)
-        - `"nearest_edge"`: Distance to the nearest edge (outer or inner) of any polygon. 
+        - `"nearest_edge"`: Distance to the nearest edge (outer or inner) of any polygon.
                 Creates `{output_name}-distance_to_nearest_edge` and `{output_name}-name_of_nearest_edge` columns.
-        - `"nearest_edge_grouped"`: For each group of shapes with the same name, compute the distance to the edge that is nearest. 
+        - `"nearest_edge_grouped"`: For each group of shapes with the same name, compute the distance to the edge that is nearest.
                 Creates `{output_name}-distance_to_nearest_edge_of_<name>` and `{output_name}-name_of_nearest_edge_of_<name>` columns.
-        - `"all_edges"`: For each individual polygon, compute the distance to its edge. 
+        - `"all_edges"`: For each individual polygon, compute the distance to its edge.
                 Creates `{output_name}-distance_to_edge_of_<shape_unique_name>` column.
-        
+
         Outer edge distances (For Polygon and MultiPolygon geometries)
-        - `"nearest_outer_edge"`: Distance to the nearest outer edge of any polygon. 
+        - `"nearest_outer_edge"`: Distance to the nearest outer edge of any polygon.
                 Creates `{output_name}-distance_to_nearest_outer_edge` and `{output_name}-name_of_nearest_outer_edge` columns.
-        - `"nearest_outer_edge_grouped"`: For each group of shapes with the same name, compute the distance to the outer edge that is nearest. 
+        - `"nearest_outer_edge_grouped"`: For each group of shapes with the same name, compute the distance to the outer edge that is nearest.
                 Creates `{output_name}-distance_to_nearest_outer_edge_of_<name>` and `{output_name}-name_of_nearest_outer_edge_of_<name>` columns.
-        - `"all_outer_edges"`: For each individual polygon, compute the distance to its outer edge. 
+        - `"all_outer_edges"`: For each individual polygon, compute the distance to its outer edge.
                 Creates `{output_name}-distance_to_outer_edge_of_<shape_unique_name>` column.
-        
+
         Inner edge (hole) distances (For Polygon and MultiPolygon geometries)
-        - `"nearest_inner_edge"`: Distance to the nearest interior edge (“hole”) of any polygon. 
+        - `"nearest_inner_edge"`: Distance to the nearest interior edge (“hole”) of any polygon.
                 Creates `{output_name}-distance_to_nearest_inner_edge` and `{output_name}-name_of_nearest_inner_edge` columns.
-        - `"nearest_inner_edge_grouped"`: For each group of shapes with the same name, compute the distance to the nearest inner edge of that group. 
+        - `"nearest_inner_edge_grouped"`: For each group of shapes with the same name, compute the distance to the nearest inner edge of that group.
                 Creates `{output_name}-distance_to_nearest_inner_edge_of_<name>` and `{output_name}-name_of_nearest_inner_edge_of_<name>` columns.
-        - `"nearest_inner_edge_grouped_unique"`: For each individual polygon, compute the distance to the nearest inner edge of that polygon. 
+        - `"nearest_inner_edge_grouped_unique"`: For each individual polygon, compute the distance to the nearest inner edge of that polygon.
                 Creates `{output_name}-distance_to_nearest_inner_edge_of_<shape_unique_name>` and `{output_name}-name_of_nearest_inner_edge_of_<shape_unique_name>` columns.
-        - `"all_inner_edges"`: For all holes, compute the distance to each inner edge. 
+        - `"all_inner_edges"`: For all holes, compute the distance to each inner edge.
                 Creates `{output_name}-distance_to_inner_edge_of_<shape_unique_name>-hole<i>` column.
-        
+
         Centroid distances (For Polygon and MultiPolygon geometries)
-        - `"nearest_centroid"`: Distance to the nearest centroid of any polygon. 
+        - `"nearest_centroid"`: Distance to the nearest centroid of any polygon.
                 Creates `{output_name}-distance_to_nearest_centroid` and `{output_name}-name_of_nearest_centroid` columns.
-        - `"nearest_centroid_grouped"`: For each group of shapes with the same name, compute the distance to the centroid that is nearest. 
+        - `"nearest_centroid_grouped"`: For each group of shapes with the same name, compute the distance to the centroid that is nearest.
                 Creates `{output_name}-distance_to_nearest_centroid_of_<name>` and `{output_name}-name_of_nearest_centroid_of_<name>` columns.
-        - `"all_centroids"`: For each individual polygon, compute the distance to its centroid. 
+        - `"all_centroids"`: For each individual polygon, compute the distance to its centroid.
                 Creates `{output_name}-distance_to_centroid_of_<shape_unique_name>` column.
-                
+
         Point distances (For Point geometries)
         - `"nearest_point"`: Distance to the nearest point.
                 Creates `{output_name}-distance_to_nearest_point` and `{output_name}-name_of_nearest_point` columns.
@@ -272,72 +288,71 @@ def compute_distance_to_shapes(
                 Creates `{output_name}-distance_to_nearest_point_of_<name>` and `{output_name}-name_of_nearest_point_of_<name>` columns.
         - `"all_points"`: For each individual Point, compute the distance to point coordinates.
                 Creates `{output_name}-distance_to_point_<shape_unique_name>` column.
-            
+
     spatial_key
         Key in `sdata.tables[table_layer].obsm` containing spatial coordinates. Ignored if `xy_columns` is provided.
     xy_columns
         Tuple of column names in `sdata.tables[table_layer].obs` containing the x and y coordinates the cells.
-        If None, defaults to using coordinates from `sdata.tables[table_layer].obsm[spatial_key]`. 
+        If None, defaults to using coordinates from `sdata.tables[table_layer].obsm[spatial_key]`.
     overwrite
         If True, overwrites the `output_table_layer` if it already exists in `sdata`.
-        
+
     Notes
-    -------
+    -----
     - Only `Polygon`, `MultiPolygon` and `Point` geometries are supported. Other geometries (e.g., `LineString`, `MultiPoint`) are skipped.
-    
+
     Returns
     -------
     Modified `sdata` object with updated table layer.
     """
-    
+    if modes is None:
+        modes = ["all_edges"]
     if output_name is not None:
         output_name = f"{output_name}-"
     elif output_name is None:
         output_name = ""
-    
+
     # Create copy of shapes layer
     gdf = sdata.shapes[shapes_layer].copy()
-    
+
     # Create copy of table layer
     adata = sdata.tables[table_layer].copy()
-    
+
     # Filter out geometries that are not Polygon, MultiPolygon or Point
     supported_mask = gdf.geometry.apply(lambda x: isinstance(x, (Polygon, MultiPolygon, Point)))
     skipped = len(gdf) - supported_mask.sum()
     if skipped > 0:
         log.info(f"Skipped {skipped} geometries in {shapes_layer} that are not Polygon, MultiPolygon or Point.")
-        
+
     gdf = gdf[supported_mask].copy().reset_index(drop=True)
-    
+
     # Separate gdf by type
     gdf_polygons = gdf[gdf.geometry.geom_type.isin(["Polygon", "MultiPolygon"])].copy()
     gdf_points = gdf[gdf.geometry.geom_type == "Point"].copy()
 
     has_polygons = not gdf_polygons.empty
     has_points = not gdf_points.empty
-    
+
     if not has_polygons and not has_points:
-        log.warning(f"No supported geometries (Polygon, MultiPolygon, Point) found. Skipping addition of table layer '{output_table_layer}' to sdata.")
+        log.warning(
+            f"No supported geometries (Polygon, MultiPolygon, Point) found. Skipping addition of table layer '{output_table_layer}' to sdata."
+        )
         return sdata
-        
+
     # Get cell coordinates
     if xy_columns is not None:
         x_col, y_col = xy_columns
         coords = adata.obs[[x_col, y_col]].to_numpy()
     else:
         if spatial_key not in adata.obsm:
-            raise KeyError(
-                f"No spatial coordinates found in `obsm['{spatial_key}']` and `xy_columns` not provided.")
+            raise KeyError(f"No spatial coordinates found in `obsm['{spatial_key}']` and `xy_columns` not provided.")
         coords = adata.obsm[spatial_key]
         if coords.shape[1] != 2:
             raise ValueError(f"`obsm['{spatial_key}']` must have shape (n_cells, 2).")
-        
+
     # Build point GeoDataFrame
-    pts = gpd.GeoSeries(
-        [Point(x, y) for x, y in coords],
-        crs=gdf.crs
-    )
-    
+    pts = gpd.GeoSeries([Point(x, y) for x, y in coords], crs=gdf.crs)
+
     pts_gdf = gpd.GeoDataFrame({"geometry": pts}, crs=gdf.crs).set_index(adata.obs.index)
 
     # Polygon and MultiPolygon
@@ -367,21 +382,12 @@ def compute_distance_to_shapes(
         ext_gdf = gpd.GeoDataFrame({unique_shape_names_column: names}, geometry=exteriors, crs=gdf.crs)
         int_gdf = gpd.GeoDataFrame({unique_shape_names_column: names}, geometry=interiors, crs=gdf.crs)
 
-        # Edges (outer and inner)     
+        # Edges (outer and inner)
         if "nearest_edge" in modes:
             log.info("Calculating 'nearest_edge' distances'")
-            all_edges_gdf = gpd.GeoDataFrame(
-                pd.concat([ext_gdf, int_gdf], ignore_index=True),
-                crs=gdf.crs
-            )
-            joined = gpd.sjoin_nearest(
-                pts_gdf, 
-                all_edges_gdf,
-                how="left", distance_col="dist"
-            )
-            adata.obs[f"{output_name}distance_to_nearest_edge"] = (
-                joined["dist"].to_numpy() * pixel_size_um
-            )
+            all_edges_gdf = gpd.GeoDataFrame(pd.concat([ext_gdf, int_gdf], ignore_index=True), crs=gdf.crs)
+            joined = gpd.sjoin_nearest(pts_gdf, all_edges_gdf, how="left", distance_col="dist")
+            adata.obs[f"{output_name}distance_to_nearest_edge"] = joined["dist"].to_numpy() * pixel_size_um
             adata.obs[f"{output_name}name_of_nearest_edge"] = joined[unique_shape_names_column]
 
         if "nearest_edge_grouped" in modes:
@@ -389,7 +395,7 @@ def compute_distance_to_shapes(
             for name, group in gdf_polygons.groupby(shape_names_column):
                 edges = []
                 labels = []
-                for idx, row in group.iterrows():
+                for _idx, row in group.iterrows():
                     edge_lines = _extract_exterior_lines(row.geometry) + _extract_interior_lines(row.geometry)
                     edges.extend(edge_lines)
                     labels.extend([row[unique_shape_names_column]] * len(edge_lines))
@@ -397,33 +403,31 @@ def compute_distance_to_shapes(
                 edge_gdf = gpd.GeoDataFrame({"geometry": edges, unique_shape_names_column: labels}, crs=gdf.crs)
                 joined = gpd.sjoin_nearest(pts_gdf, edge_gdf, how="left", distance_col="dist")
 
-                adata.obs[f"{output_name}distance_to_nearest_edge_of_{name}"] = joined["dist"].to_numpy() * pixel_size_um
+                adata.obs[f"{output_name}distance_to_nearest_edge_of_{name}"] = (
+                    joined["dist"].to_numpy() * pixel_size_um
+                )
                 adata.obs[f"{output_name}name_of_nearest_edge_of_{name}"] = joined[unique_shape_names_column]
-                
+
         if "all_edges" in modes:
             log.info("Calculating 'all_edges' distances'")
             for _, feat in gdf_polygons.reset_index(drop=True).iterrows():
-                adata.obs[f"{output_name}distance_to_edge_of_{feat[unique_shape_names_column]}"] = pts.distance(feat.geometry.boundary).to_numpy() * pixel_size_um
+                adata.obs[f"{output_name}distance_to_edge_of_{feat[unique_shape_names_column]}"] = (
+                    pts.distance(feat.geometry.boundary).to_numpy() * pixel_size_um
+                )
 
         # Outer edges
         if "nearest_outer_edge" in modes:
             log.info("Calculating 'nearest_outer_edge' distances'")
-            joined = gpd.sjoin_nearest(
-                pts_gdf, 
-                ext_gdf,
-                how="left", distance_col="dist"
-            )
-            adata.obs[f"{output_name}distance_to_nearest_outer_edge"] = (
-                joined["dist"].to_numpy() * pixel_size_um
-            )
+            joined = gpd.sjoin_nearest(pts_gdf, ext_gdf, how="left", distance_col="dist")
+            adata.obs[f"{output_name}distance_to_nearest_outer_edge"] = joined["dist"].to_numpy() * pixel_size_um
             adata.obs[f"{output_name}name_of_nearest_outer_edge"] = joined[unique_shape_names_column]
-            
+
         if "nearest_outer_edge_grouped" in modes:
             log.info("Calculating 'nearest_outer_edge_grouped' distances'")
             for name, group in gdf_polygons.groupby(shape_names_column):
                 edges = []
                 labels = []
-                for idx, row in group.iterrows():
+                for _idx, row in group.iterrows():
                     edge_lines = _extract_exterior_lines(row.geometry)
                     edges.extend(edge_lines)
                     labels.extend([row[unique_shape_names_column]] * len(edge_lines))
@@ -431,13 +435,17 @@ def compute_distance_to_shapes(
                 edge_gdf = gpd.GeoDataFrame({"geometry": edges, unique_shape_names_column: labels}, crs=gdf.crs)
                 joined = gpd.sjoin_nearest(pts_gdf, edge_gdf, how="left", distance_col="dist")
 
-                adata.obs[f"{output_name}distance_to_nearest_outer_edge_of_{name}"] = joined["dist"].to_numpy() * pixel_size_um
+                adata.obs[f"{output_name}distance_to_nearest_outer_edge_of_{name}"] = (
+                    joined["dist"].to_numpy() * pixel_size_um
+                )
                 adata.obs[f"{output_name}name_of_nearest_outer_edge_of_{name}"] = joined[unique_shape_names_column]
 
         if "all_outer_edges" in modes:
             log.info("Calculating 'all_outer_edges' distances'")
             for _, feat in gdf_polygons.reset_index(drop=True).iterrows():
-                adata.obs[f"{output_name}distance_to_outer_edge_of_{feat[unique_shape_names_column]}"] = pts.distance(feat.geometry.exterior).to_numpy() * pixel_size_um
+                adata.obs[f"{output_name}distance_to_outer_edge_of_{feat[unique_shape_names_column]}"] = (
+                    pts.distance(feat.geometry.exterior).to_numpy() * pixel_size_um
+                )
 
         # Inner edges
         hole_geoms = []
@@ -446,8 +454,8 @@ def compute_distance_to_shapes(
         for _, row in gdf_polygons.reset_index(drop=True).iterrows():
             base = row[unique_shape_names_column]
             geom = row.geometry
-            
-            holes =_extract_interior_lines(geom)
+
+            holes = _extract_interior_lines(geom)
 
             if len(holes) == 0:
                 continue
@@ -456,29 +464,18 @@ def compute_distance_to_shapes(
                 hole = holes[0]
                 hole_geoms.append(LineString(hole.coords))
                 hole_names.append(base)
-                
+
             else:
                 for i, hole in enumerate(holes, start=1):
                     hole_geoms.append(LineString(hole.coords))
                     hole_names.append(f"{base}-hole{i}")
 
-        holes_gdf = gpd.GeoDataFrame(
-            {unique_shape_names_column: hole_names},
-            geometry=hole_geoms,
-            crs=gdf.crs
-        )
+        holes_gdf = gpd.GeoDataFrame({unique_shape_names_column: hole_names}, geometry=hole_geoms, crs=gdf.crs)
 
         if "nearest_inner_edge" in modes and not holes_gdf.empty:
             log.info("Calculating 'nearest_inner_edge' distances'")
-            joined = gpd.sjoin_nearest(
-                pts_gdf, 
-                holes_gdf,
-                how="left", 
-                distance_col="dist"
-            )
-            adata.obs[f"{output_name}distance_to_nearest_inner_edge"] = (
-                joined["dist"].to_numpy() * pixel_size_um
-            )
+            joined = gpd.sjoin_nearest(pts_gdf, holes_gdf, how="left", distance_col="dist")
+            adata.obs[f"{output_name}distance_to_nearest_inner_edge"] = joined["dist"].to_numpy() * pixel_size_um
             adata.obs[f"{output_name}name_of_nearest_inner_edge"] = joined[unique_shape_names_column]
 
         if "nearest_inner_edge_grouped" in modes:
@@ -487,7 +484,7 @@ def compute_distance_to_shapes(
                 hole_lines = []
                 hole_labels = []
 
-                for idx, row in group.iterrows():
+                for _idx, row in group.iterrows():
                     base = row[unique_shape_names_column]
                     for i, hole in enumerate(_extract_interior_lines(row.geometry), start=1):
                         hole_lines.append(LineString(hole.coords))
@@ -496,19 +493,18 @@ def compute_distance_to_shapes(
                 if not hole_lines:
                     continue
 
-                hole_gdf = gpd.GeoDataFrame({
-                    "geometry": hole_lines,
-                    "hole_name": hole_labels
-                }, crs=gdf.crs)
+                hole_gdf = gpd.GeoDataFrame({"geometry": hole_lines, "hole_name": hole_labels}, crs=gdf.crs)
 
                 joined = gpd.sjoin_nearest(pts_gdf, hole_gdf, how="left", distance_col="dist")
 
-                adata.obs[f"{output_name}distance_to_nearest_inner_edge_of_{name}"] = joined["dist"].to_numpy() * pixel_size_um
+                adata.obs[f"{output_name}distance_to_nearest_inner_edge_of_{name}"] = (
+                    joined["dist"].to_numpy() * pixel_size_um
+                )
                 adata.obs[f"{output_name}name_of_nearest_inner_edge_of_{name}"] = joined["hole_name"]
 
         if "nearest_inner_edge_grouped_unique" in modes:
             log.info("Calculating 'nearest_inner_edge_grouped_unique' distances'")
-            for idx, row in gdf_polygons.iterrows():
+            for _idx, row in gdf_polygons.iterrows():
                 base = row[unique_shape_names_column]
                 holes = _extract_interior_lines(row.geometry)
 
@@ -516,16 +512,15 @@ def compute_distance_to_shapes(
                     continue
 
                 hole_geoms = [LineString(hole.coords) for hole in holes]
-                hole_names = [f"{base}-hole{i+1}" for i in range(len(holes))]
+                hole_names = [f"{base}-hole{i + 1}" for i in range(len(holes))]
 
-                hole_gdf = gpd.GeoDataFrame({
-                    "geometry": hole_geoms,
-                    "hole_name": hole_names
-                }, crs=gdf.crs)
+                hole_gdf = gpd.GeoDataFrame({"geometry": hole_geoms, "hole_name": hole_names}, crs=gdf.crs)
 
                 joined = gpd.sjoin_nearest(pts_gdf, hole_gdf, how="left", distance_col="dist")
 
-                adata.obs[f"{output_name}distance_to_nearest_inner_edge_of_{base}"] = joined["dist"].to_numpy() * pixel_size_um
+                adata.obs[f"{output_name}distance_to_nearest_inner_edge_of_{base}"] = (
+                    joined["dist"].to_numpy() * pixel_size_um
+                )
                 adata.obs[f"{output_name}name_of_nearest_inner_edge_of_{base}"] = joined["hole_name"]
 
         if "all_inner_edges" in modes and not holes_gdf.empty:
@@ -535,29 +530,21 @@ def compute_distance_to_shapes(
                 col = f"{output_name}distance_to_inner_edge_of_{hole_name}"
                 adata.obs[col] = pts.distance(hole.geometry).to_numpy() * pixel_size_um
 
-        # Centroids        
+        # Centroids
         centroids_df = gdf_polygons.reset_index(drop=True)[[unique_shape_names_column]].copy()
         centroids_df["geometry"] = gdf_polygons.geometry.centroid.reset_index(drop=True)
 
-        centroids_gdf = gpd.GeoDataFrame(
-            centroids_df,
-            geometry="geometry",
-            crs=gdf.crs
-        )
+        centroids_gdf = gpd.GeoDataFrame(centroids_df, geometry="geometry", crs=gdf.crs)
 
         if "nearest_centroid" in modes:
             log.info("Calculating 'nearest_centroid' distances'")
-            joined = gpd.sjoin_nearest(
-                pts_gdf, centroids_gdf,
-                how="left",
-                distance_col="dist"
-            )
+            joined = gpd.sjoin_nearest(pts_gdf, centroids_gdf, how="left", distance_col="dist")
             adata.obs.loc[joined.index, f"{output_name}distance_to_nearest_centroid"] = (
                 joined["dist"].to_numpy() * pixel_size_um
             )
-            adata.obs.loc[joined.index, f"{output_name}name_of_nearest_centroid"] = (
-                joined[unique_shape_names_column].to_numpy()
-            )
+            adata.obs.loc[joined.index, f"{output_name}name_of_nearest_centroid"] = joined[
+                unique_shape_names_column
+            ].to_numpy()
 
         if "nearest_centroid_grouped" in modes:
             log.info("Calculating 'nearest_centroid_grouped' distances'")
@@ -565,28 +552,27 @@ def compute_distance_to_shapes(
                 centroids = group.geometry.centroid
                 labels = group[unique_shape_names_column].tolist()
 
-                centroid_gdf = gpd.GeoDataFrame({
-                    "geometry": centroids,
-                    unique_shape_names_column: labels
-                }, crs=gdf.crs)
+                centroid_gdf = gpd.GeoDataFrame({"geometry": centroids, unique_shape_names_column: labels}, crs=gdf.crs)
 
                 joined = gpd.sjoin_nearest(pts_gdf, centroid_gdf, how="left", distance_col="dist")
 
-                adata.obs[f"{output_name}distance_to_nearest_centroid_of_{name}"] = joined["dist"].to_numpy() * pixel_size_um
+                adata.obs[f"{output_name}distance_to_nearest_centroid_of_{name}"] = (
+                    joined["dist"].to_numpy() * pixel_size_um
+                )
                 adata.obs[f"{output_name}name_of_nearest_centroid_of_{name}"] = joined[unique_shape_names_column]
 
         if "all_centroids" in modes:
             log.info("Calculating 'all_centroids' distances'")
-            for idx, feat in gdf_polygons.reset_index(drop=True).iterrows():
-                adata.obs[f"{output_name}distance_to_centroid_of_{feat[unique_shape_names_column]}"] = pts.distance(feat.geometry.centroid).to_numpy() * pixel_size_um
+            for _idx, feat in gdf_polygons.reset_index(drop=True).iterrows():
+                adata.obs[f"{output_name}distance_to_centroid_of_{feat[unique_shape_names_column]}"] = (
+                    pts.distance(feat.geometry.centroid).to_numpy() * pixel_size_um
+                )
 
     # Point
     if has_points:
         if "nearest_point" in modes:
             log.info("Calculating 'nearest_point' distances'")
-            joined = gpd.sjoin_nearest(
-                pts_gdf, gdf_points, how="left", distance_col="dist"
-            )
+            joined = gpd.sjoin_nearest(pts_gdf, gdf_points, how="left", distance_col="dist")
             adata.obs[f"{output_name}distance_to_nearest_point"] = joined["dist"].to_numpy() * pixel_size_um
             adata.obs[f"{output_name}name_of_nearest_point"] = joined[f"{shape_names_column}-unique"]
 
@@ -594,22 +580,25 @@ def compute_distance_to_shapes(
             log.info("Calculating 'nearest_point_grouped' distances'")
             for name, group in gdf_points.groupby(shape_names_column):
                 joined = gpd.sjoin_nearest(pts_gdf, group, how="left", distance_col="dist")
-                adata.obs[f"{output_name}distance_to_nearest_point_of_{name}"] = joined["dist"].to_numpy() * pixel_size_um
+                adata.obs[f"{output_name}distance_to_nearest_point_of_{name}"] = (
+                    joined["dist"].to_numpy() * pixel_size_um
+                )
                 adata.obs[f"{output_name}name_of_nearest_point_of_{name}"] = joined[f"{shape_names_column}-unique"]
 
         if "all_points" in modes:
             log.info("Calculating 'all_points' distances'")
             for _, row in gdf_points.iterrows():
-                adata.obs[f"{output_name}distance_to_point_{row[unique_shape_names_column]}"] = pts.distance(row.geometry).to_numpy() * pixel_size_um
+                adata.obs[f"{output_name}distance_to_point_{row[unique_shape_names_column]}"] = (
+                    pts.distance(row.geometry).to_numpy() * pixel_size_um
+                )
 
-
-    # Add table layer  
+    # Add table layer
     sdata = add_table_layer(
         sdata,
-        adata = adata,
-        output_layer = output_table_layer,
-        region = adata.obs[_REGION_KEY].cat.categories.to_list(),
-        overwrite = overwrite,
+        adata=adata,
+        output_layer=output_table_layer,
+        region=adata.obs[_REGION_KEY].cat.categories.to_list(),
+        overwrite=overwrite,
     )
-    
+
     return sdata


### PR DESCRIPTION
This PR contains functions for several basic operations for spatial data analysis:

**hp.sh.filter_by_morphology**: Allows filtering a shapes layer based on morphological features (area, perimeter, circularity, ...). Can be used to clean cells after segmentation.

**hp.sh.filter_by_shapes**: Allows filtering a shapes layer based on a secondary shapes layer containing region annotation. Can be used to clean cells/polygons occurring in artifacts, outside of the tissue, etc..

**hp.tb.filter_numerical**: Allows filtering a table layer based on a numerical column in .obs. This is a generalization of hp.tb.filter_on_size.

**hp.tb.filter_categorical**: Allows filtering a table layer based on a categorical column in .obs.

**hp.assign_cells_to_shapes**: Allows determining whether a cell occurs in a region annotation. Creates a column or multiple columns in .obs.

**hp.tb.compute_distance_to_shapes**: Allows computing distances per cell to polygons in a shapes layer. Multiple modes are included to support different use-cases. E.g. computing distance of cell to nearest polygon, computing distances to all centroids of all polygons, ...

**hp.sh.prep_region_annotations**: Prepares region annotations in a shapes layer for `hp.sh.filter_by_morphology`, `hp.tb.assign_cells_to_shapes` and `hp.tb.compute_distance_to_shapes`.

These functions were tested for shapes and table layers occurring in the same coordinate space and no transformations were required. More challenging use-cases still need to be tested/supported.

