### PR TITLE
[fix] Cellpose 4.2 compatibility 

### DIFF
--- a/src/harpy/image/segmentation/segmentation_models/_cellpose.py
+++ b/src/harpy/image/segmentation/segmentation_models/_cellpose.py
@@ -71,6 +71,7 @@ def cellpose_callable(
         See documentation of `cellpose.models.CellposeModel.eval` for full description.
     invert
         Invert image pixel intensity before running network. Defaults to `False`.
+        Only supported for cellpose versions `<4.2.0` and raises a `ValueError` on newer versions. 
     diameter
         The estimated diameter of cells (in pixels).
     flow_threshold
@@ -194,9 +195,11 @@ def cellpose_callable(
 
     if cellpose_version < version.parse("4.2.0"):
         common_args["invert"] = invert
-    else:
-        log.warning("``invert`` argument is not supported in cellpose>=4.2 and will be ignored.")
-
+    elif invert:
+      raise ValueError(
+          "`invert` was removed from 'CellposeModel.eval' in cellpose>=4.2.0. "
+          "Please invert the image before passing with it with `invert=False` to `harpy.im.segment`, or pin 'cellpose<4.2.0'."
+      )
     results = model.eval(**common_args)
 
     masks = results[0][0]

--- a/src/harpy/image/segmentation/segmentation_models/_cellpose.py
+++ b/src/harpy/image/segmentation/segmentation_models/_cellpose.py
@@ -171,7 +171,6 @@ def cellpose_callable(
         "channel_axis": 3 if do_3D_segmentation else 2,
         "z_axis": 0 if do_3D_segmentation else None,
         "normalize": normalize,
-        "invert": invert,
         "rescale": None,  # not supported in harpy.
         "diameter": diameter,
         "flow_threshold": flow_threshold,

--- a/src/harpy/image/segmentation/segmentation_models/_cellpose.py
+++ b/src/harpy/image/segmentation/segmentation_models/_cellpose.py
@@ -71,7 +71,7 @@ def cellpose_callable(
         See documentation of `cellpose.models.CellposeModel.eval` for full description.
     invert
         Invert image pixel intensity before running network. Defaults to `False`.
-        Only supported for cellpose versions `<4.2.0` and raises a `ValueError` on newer versions. 
+        Only supported for cellpose versions `<4.2.0` and raises a `ValueError` on newer versions.
     diameter
         The estimated diameter of cells (in pixels).
     flow_threshold
@@ -196,10 +196,10 @@ def cellpose_callable(
     if cellpose_version < version.parse("4.2.0"):
         common_args["invert"] = invert
     elif invert:
-      raise ValueError(
-          "`invert` was removed from 'CellposeModel.eval' in cellpose>=4.2.0. "
-          "Please invert the image before passing with it with `invert=False` to `harpy.im.segment`, or pin 'cellpose<4.2.0'."
-      )
+        raise ValueError(
+            "`invert` was removed from 'CellposeModel.eval' in cellpose>=4.2.0. "
+            "Please invert the image before passing with it with `invert=False` to `harpy.im.segment`, or pin 'cellpose<4.2.0'."
+        )
     results = model.eval(**common_args)
 
     masks = results[0][0]

--- a/src/harpy/image/segmentation/segmentation_models/_cellpose.py
+++ b/src/harpy/image/segmentation/segmentation_models/_cellpose.py
@@ -193,6 +193,11 @@ def cellpose_callable(
     else:
         common_args["flow3D_smooth"] = flow3D_smooth
 
+    if cellpose_version < version.parse("4.2.0"):
+        common_args["invert"] = invert
+    else:
+        log.warning("``invert`` argument is not supported in cellpose>=4.2 and will be ignored.")
+
     results = model.eval(**common_args)
 
     masks = results[0][0]


### PR DESCRIPTION
As discussed in #259, `invert` got removed as argument to `model.eval` in cellpose v4.2+, making harpy incompatible with the latest cellpose versions. 

The `cellpose_callable` function documents now handles `invert` in a version-specific manner:
- it documents the changed behavior
- For cellpose versions greater than 4.2, it raises an error when `invert=True`. 